### PR TITLE
Remove unused getTeamTrickPilePosition

### DIFF
--- a/src/utils/positionMapping.ts
+++ b/src/utils/positionMapping.ts
@@ -34,11 +34,3 @@ export const mapUIToGamePosition = (uiPos: UIPosition): GamePosition => {
   return mapping[uiPos];
 };
 
-/**
- * Maps team positioning to game positions for trick piles
- */
-export const getTeamTrickPilePosition = (teamId: 'A' | 'B'): GamePosition => {
-  // Team A (human team) gets south position (bottom-right in UI)
-  // Team B (AI team) gets north position (top-left in UI)
-  return teamId === 'A' ? 'south' : 'north';
-};


### PR DESCRIPTION
## Summary
- remove getTeamTrickPilePosition from positionMapping utils

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm run test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842c550839c8327947ac0746559ad8d