### PR TITLE
Remove wonTricks arrays from state

### DIFF
--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -15,6 +15,7 @@ import ContractIndicator from './ContractIndicator';
 import { Card as CardType, GamePhase, Player } from '../core/types';
 import { gameManager } from '../game/GameManager';
 import { selectCard } from '../store/gameSlice';
+import { selectTeamATricks, selectTeamBTricks } from '../store/selectors';
 import { mapGameToUIPosition } from '../utils/positionMapping';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -37,6 +38,8 @@ const GameTable: React.FC = () => {
   const declarationTracking = useAppSelector(state => state.game.declarationTracking);
   const completedTricks = useAppSelector(state => state.game.completedTricks);
   const teams = useAppSelector(state => state.game.teams);
+  const teamATricks = useAppSelector(selectTeamATricks);
+  const teamBTricks = useAppSelector(selectTeamBTricks);
   const trickNumber = useAppSelector(state => state.game.trickNumber);
   const earlyTermination = useAppSelector(state => state.game.earlyTermination);
   const biddingHistory = useAppSelector(state => state.game.biddingHistory);
@@ -54,11 +57,11 @@ const GameTable: React.FC = () => {
       console.log('Teams data:', {
         teamA: teams.A,
         teamB: teams.B,
-        teamATricks: teams.A?.wonTricks?.length || 0,
-        teamBTricks: teams.B?.wonTricks?.length || 0
+        teamATricks: teamATricks.length,
+        teamBTricks: teamBTricks.length
       });
     }
-  }, [players, teams]);
+  }, [players, teams, teamATricks, teamBTricks]);
   // Track viewing state
   const [trickWinner, setTrickWinner] = useState<string | undefined>(undefined);
   const [shownInTrick, setShownInTrick] = useState<Record<string, number>>({});
@@ -324,12 +327,11 @@ const GameTable: React.FC = () => {
       {/* Contract Indicator - manages its own responsive positioning */}
       <ContractIndicator />
         {/* Team B Trick Pile - Upper Left */}
-      {teams.B?.wonTricks && teams.B.wonTricks.length > 0 && (
+      {teamBTricks.length > 0 && (
         <div className="absolute top-2 left-2 sm:top-4 sm:left-4 lg:top-6 lg:left-6 z-10">
-          <TrickPile 
-            tricks={teams.B.wonTricks} 
-            teamId="B" 
-            position="north" 
+          <TrickPile
+            teamId="B"
+            position="north"
             currentTrickNumber={trickNumber}
             isLastTrickPile={completedTricks.length > 0 && completedTricks[completedTricks.length - 1]?.winner?.teamId === 'B'}
           />
@@ -337,12 +339,11 @@ const GameTable: React.FC = () => {
       )}
       
       {/* Team A Trick Pile - Lower Right (Human's team) */}
-      {teams.A?.wonTricks && teams.A.wonTricks.length > 0 && (
+      {teamATricks.length > 0 && (
         <div className="absolute bottom-2 right-2 sm:bottom-4 sm:right-4 lg:bottom-6 lg:right-6 z-10">
-          <TrickPile 
-            tricks={teams.A.wonTricks} 
-            teamId="A" 
-            position="south" 
+          <TrickPile
+            teamId="A"
+            position="south"
             currentTrickNumber={trickNumber}
             isLastTrickPile={completedTricks.length > 0 && completedTricks[completedTricks.length - 1]?.winner?.teamId === 'A'}
           />

--- a/src/components/TrickPile.tsx
+++ b/src/components/TrickPile.tsx
@@ -1,22 +1,20 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Trick } from '../core/types';
-import Card from './Card';
 import TrickPileViewer from './TrickPileViewer';
-import { useSelector } from 'react-redux';
-import { RootState } from '../store';
+import { useAppSelector } from '../store/hooks';
+import { selectTeamATricks, selectTeamBTricks } from '../store/selectors';
 
 interface TrickPileProps {
-  tricks: Trick[];
   teamId: 'A' | 'B';
   position: 'north' | 'east' | 'south' | 'west';
   currentTrickNumber: number;
   isLastTrickPile?: boolean;
 }
 
-const TrickPile: React.FC<TrickPileProps> = ({ tricks, teamId, position, currentTrickNumber, isLastTrickPile = false }) => {
+const TrickPile: React.FC<TrickPileProps> = ({ teamId, position, currentTrickNumber, isLastTrickPile = false }) => {
   const [showViewer, setShowViewer] = useState(false);
-  const settings = useSelector((state: RootState) => state.game.settings);
+  const settings = useAppSelector(state => state.game.settings);
+  const tricks = useAppSelector(teamId === 'A' ? selectTeamATricks : selectTeamBTricks);
   const cardSize = settings?.cardSize || 'medium';
   const showPoints = settings?.showTrickPilePoints || false;
   
@@ -40,8 +38,6 @@ const TrickPile: React.FC<TrickPileProps> = ({ tricks, teamId, position, current
   // Piles are now positioned by parent container using center-based layout
   // No need for absolute positioning here
   
-  // Get team color
-  const teamColor = teamId === 'A' ? 'blue' : 'red';
   
   return (
     <>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -136,8 +136,8 @@ export interface GameState {
   // Players and teams
   players: Player[];
   teams: {
-    A: { players: Player[]; score: number; roundScore: number; wonTricks?: Trick[]; trickPilePosition?: string | null };
-    B: { players: Player[]; score: number; roundScore: number; wonTricks?: Trick[]; trickPilePosition?: string | null };
+    A: { players: Player[]; score: number; roundScore: number };
+    B: { players: Player[]; score: number; roundScore: number };
   };
   
   // Current round state

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -27,14 +27,16 @@ export const selectTrumpSuit = (state: RootState) => state.game.trumpSuit;
 export const selectCurrentTrick = (state: RootState) => state.game.currentTrick;
 export const selectContract = (state: RootState) => state.game.contract;
 
+export const selectCompletedTricks = (state: RootState) => state.game.completedTricks;
+
 // Valid moves selector
 export const selectValidMovesForCurrentPlayer = createSelector(
-  [selectCurrentPlayer, selectCurrentTrick, selectTrumpSuit, selectContract],
-  (currentPlayer, currentTrick, trumpSuit, contract) => {
-    if (!currentPlayer || !currentPlayer.hand || !trumpSuit || !contract) {
+  [selectCurrentPlayer, selectCurrentTrick, selectTrumpSuit],
+  (currentPlayer, currentTrick, trumpSuit) => {
+    if (!currentPlayer || !currentPlayer.hand || !trumpSuit) {
       return [];
     }
-    return getLegalPlays(currentPlayer.hand, currentTrick, trumpSuit, contract);
+    return getLegalPlays(currentPlayer.hand, currentTrick, trumpSuit);
   }
 );
 
@@ -62,6 +64,16 @@ export const selectTeamScores = createSelector(
     teamA: scores.team1,
     teamB: scores.team2
   })
+);
+
+export const selectTeamATricks = createSelector(
+  [selectCompletedTricks],
+  (tricks) => tricks.filter(t => t.winner?.teamId === 'A')
+);
+
+export const selectTeamBTricks = createSelector(
+  [selectCompletedTricks],
+  (tricks) => tricks.filter(t => t.winner?.teamId === 'B')
 );
 
 // Game state summary selector

--- a/src/utils/soundManager.ts
+++ b/src/utils/soundManager.ts
@@ -47,7 +47,7 @@ class SoundManager {
       // Clone the audio to allow overlapping sounds
       const clone = sound.cloneNode() as HTMLAudioElement;
       clone.volume = volume ?? this.volume;
-      clone.play().catch(err => {
+      clone.play().catch(_err => {
         // Silently fail - sounds are optional
         // console.warn(`Failed to play sound ${soundName}:`, err);
       });

--- a/src/utils/testScenarios.ts
+++ b/src/utils/testScenarios.ts
@@ -1,4 +1,4 @@
-import { Card, Suit, Rank, Declaration, DeclarationType } from '../core/types';
+import { Card, Suit, Rank, DeclarationType } from '../core/types';
 
 // Test scenarios for declaration system testing
 
@@ -37,26 +37,26 @@ export const createTestDeclarations = () => {
   return {
     strongDeclarations: {
       fourJacks: {
-        type: DeclarationType.FourOfAKind,
+        type: DeclarationType.Carre,
         cards: fourJacks,
         points: 200
       },
       fourNines: {
-        type: DeclarationType.FourOfAKind,
+        type: DeclarationType.Carre,
         cards: fourNines,
         points: 150
       }
     },
     mediumDeclarations: {
       sequence4: {
-        type: DeclarationType.Sequence,
+        type: DeclarationType.Quarte,
         cards: sequence4,
         points: 50
       }
     },
     weakDeclarations: {
       sequence3: {
-        type: DeclarationType.Sequence,
+        type: DeclarationType.Tierce,
         cards: sequence3,
         points: 20
       }


### PR DESCRIPTION
## Summary
- simplify GameState teams by dropping wonTricks and trickPilePosition
- compute team piles from completedTricks using new selectors
- refactor GameTable and TrickPile components to use selectors
- update completeTrick reducer to only push into completedTricks
- fix unused imports that broke compilation
- fix several TypeScript errors in selectors, gameSlice, sound manager and test utilities

## Testing
- `npm run build` *(fails: TS errors remain in unrelated files)*
- `npm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6842c54f40308327a3907b30bb2dae9f