### PR TITLE
Update docs about cleanup and tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,13 @@ The project has successfully completed a comprehensive responsive design overhau
 - Single source of truth in tokens.css
 - Modern CSS architecture with @layer system
 - Basic accessibility restored (keyboard nav, ARIA labels)
+- Removed obsolete `ResponsiveCardHand.css` and cleaned built asset directories
+  (`dist-baseline/` and `purged-css/`)
+- Added tokens `--announcement-border-width`, `--ph-card-gap`,
+  `--ph-container-padding` and `--ph-card-scale` for unified spacing and scale
+  control
+- `PlayerHandFlex` now relies on these tokens for its gap, container padding and
+  card scaling
 
 **Documentation Created**:
 - `RESPONSIVE_FIXES_IMPLEMENTED.md` - Complete implementation summary

--- a/changelog.md
+++ b/changelog.md
@@ -145,3 +145,16 @@
   - Changed to medium-sized cards
 - **Result**: Clean, unobtrusive modal that shows essential info without distraction
 - **Kept**: CSS Grid layout, golden glow on winner, cross formation
+
+## 2025-01-07 - Cleanup & Token Additions
+
+### Maintenance
+- Removed obsolete `ResponsiveCardHand.css` and deleted built asset directories
+  (`dist-baseline/` and `purged-css/`) from the repository.
+- Added new design tokens in `tokens.css`:
+  - `--announcement-border-width`
+  - `--ph-card-gap`
+  - `--ph-container-padding`
+  - `--ph-card-scale`
+- Updated `PlayerHandFlex` to rely entirely on these tokens for spacing, padding
+  and card scaling.


### PR DESCRIPTION
## Summary
- document removing old built assets and obsolete ResponsiveCardHand.css
- mention new tokens in tokens.css
- note that PlayerHandFlex now uses tokens for spacing, padding and scale

## Testing
- `npm test` *(fails: browsers not installed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842d18efb048327abe1ba0da3ee2841