### PR TITLE
Remove local ph card scale

### DIFF
--- a/src/components/PlayerHandFlex.css
+++ b/src/components/PlayerHandFlex.css
@@ -216,15 +216,6 @@ gap: var(--ph-card-gap, var(--card-gap));
   transform: rotate(-90deg);
 }
 
-/* Card size controls from Settings */
-.ph-flex-wrapper {
-  /* Responsive card scale using clamp() - smooth scaling from 0.5 to 1.0 */
-  --ph-card-scale: clamp(
-    0.5,     /* minimum scale at 320px viewport */
-    0.5 + (100vw - 320px) / 1440,  /* smooth scale based on viewport */
-    1.0      /* maximum scale at 1760px+ viewport */
-  );
-}
 
 /* Container responsive properties using clamp() */
 .ph-flex-container {


### PR DESCRIPTION
## Summary
- rely on `--ph-card-scale` from tokens.css for PlayerHandFlex
- add a newline at the end of PlayerHandFlex.css

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842d191b81483278edfa36e97bc36e3