### PR TITLE
Refactor card size setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,16 +237,11 @@ function GameContent() {
 
 // Main App component
 function App() {
-  // Initialize card size from localStorage on mount
+  // Initialize card scale from localStorage on mount
   useEffect(() => {
-    const savedCardSize = localStorage.getItem('cardSize');
-    const size = savedCardSize ? parseFloat(savedCardSize) : 1.0;
-    
-    // Set CSS variables for card scaling
-    document.documentElement.style.setProperty('--card-size-human', size.toString());
-    // AI players get 5% increments (20% of human scaling)
-    const aiScale = 1.0 + (size - 1.0) * 0.2;
-    document.documentElement.style.setProperty('--card-size-ai', aiScale.toString());
+    const savedCardScale = localStorage.getItem('cardScale');
+    const size = savedCardScale ? parseFloat(savedCardScale) : 1.0;
+    document.documentElement.style.setProperty('--card-scale', size.toString());
   }, []);
 
   return (

--- a/src/components/PlayerHandFlex.css
+++ b/src/components/PlayerHandFlex.css
@@ -45,8 +45,8 @@ gap: var(--ph-card-gap, var(--card-gap));
   position: relative;
   
   /* Dynamic card dimensions with min/max constraints */
-  --dynamic-card-width: calc(var(--card-width) * var(--ph-card-scale));
-  --dynamic-card-height: calc(var(--card-height) * var(--ph-card-scale));
+  --dynamic-card-width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale));
+  --dynamic-card-height: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale));
   
   width: var(--dynamic-card-width);
   height: var(--dynamic-card-height);
@@ -159,12 +159,13 @@ gap: var(--ph-card-gap, var(--card-gap));
   justify-content: center;
 }
 
+
 .ph-flex-wrapper[data-position="north"] .ph-flex-card {
   flex: 0 0 auto;
-  width: calc(var(--card-width) * var(--ph-card-scale) * 0.7);
+  width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * 0.7);
 
   /* Negative margin for overlap - using compact ratio */
-  margin-right: calc(var(--card-width) * var(--ph-card-scale) * calc(-1 * var(--card-overlap-compact)));
+  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));
 }
 
 /* Last card shouldn't have negative margin */
@@ -174,7 +175,7 @@ gap: var(--ph-card-gap, var(--card-gap));
 
 /* Dynamic overlap based on card count for North player */
 .ph-flex-wrapper[data-position="north"][data-card-count="8"] .ph-flex-card {
-  margin-right: calc(var(--card-width) * var(--ph-card-scale) * calc(-1 * var(--card-overlap-tight)));
+  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight)));
 }
 
 /* EAST/WEST PLAYERS - Vertical flex with rotation */
@@ -189,11 +190,11 @@ gap: var(--ph-card-gap, var(--card-gap));
 .ph-flex-wrapper[data-position="east"] .ph-flex-card,
 .ph-flex-wrapper[data-position="west"] .ph-flex-card {
   flex: 0 0 auto;
-  width: calc(var(--card-width) * var(--ph-card-scale) * 0.5);
-  height: calc(var(--card-height) * var(--ph-card-scale) * 0.5);
+  width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * 0.5);
+  height: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * 0.5);
 
   /* Negative margin to create overlap - using compact ratio */
-  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * calc(-1 * var(--card-overlap-compact)));
+  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));
 }
 
 /* Last card shouldn't have negative margin */
@@ -205,7 +206,7 @@ gap: var(--ph-card-gap, var(--card-gap));
 /* Dynamic overlap based on card count for East/West players */
 .ph-flex-wrapper[data-position="east"][data-card-count="8"] .ph-flex-card,
 .ph-flex-wrapper[data-position="west"][data-card-count="8"] .ph-flex-card {
-  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * calc(-1 * var(--card-overlap-tight)));
+  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight)));
 }
 
 .ph-flex-wrapper[data-position="east"] .ph-flex-card {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -18,7 +18,7 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
   const [animationSpeed, setAnimationSpeed] = useState<'fast' | 'normal' | 'slow'>('normal');
   const [advancedAI, setAdvancedAI] = useState(false);
   const [cardSize, setCardSize] = useState<number>(
-    parseFloat(localStorage.getItem('cardSize') || '1.0')  // Default to 1.0 (100%)
+    parseFloat(localStorage.getItem('cardScale') || '1.0')  // Default to 1.0 (100%)
   );
   const [showTrickPilePoints, setShowTrickPilePoints] = useState(gameSettings?.showTrickPilePoints || false);
   const [rightClickZoom, setRightClickZoom] = useState(gameSettings?.rightClickZoom ?? true);
@@ -35,24 +35,13 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
   
   const handleCardSizeChange = (size: number) => {
     setCardSize(size);
-    localStorage.setItem('cardSize', size.toString());
-    
-    // Set CSS variables for card scaling
-    // Human player gets full 25% increments
-    document.documentElement.style.setProperty('--card-size-human', size.toString());
-    // AI players get 5% increments (20% of human scaling)
-    const aiScale = 1.0 + (size - 1.0) * 0.2;
-    document.documentElement.style.setProperty('--card-size-ai', aiScale.toString());
-    
-    // Map numeric scale to size categories for Redux (for backward compatibility)
-    let sizeCategory: 'small' | 'medium' | 'large' | 'xlarge' = 'medium';
-    if (size <= 1.25) sizeCategory = 'small';
-    else if (size <= 1.75) sizeCategory = 'medium';
-    else if (size <= 2.0) sizeCategory = 'large';
-    else sizeCategory = 'xlarge';
-    
-    dispatch(updateSettings({ cardSize: sizeCategory }));
-    gameManager.setCardSize(size);
+    localStorage.setItem('cardScale', size.toString());
+
+    // Update global card scale CSS variable
+    document.documentElement.style.setProperty('--card-scale', size.toString());
+
+    dispatch(updateSettings({ cardScale: size }));
+    gameManager.setCardScale(size);
   };
 
   const handleShowTrickPilePointsChange = (show: boolean) => {

--- a/src/components/TrickArea.css
+++ b/src/components/TrickArea.css
@@ -43,13 +43,13 @@
 
 /* Override card dimensions in trick area based on who played them */
 .trick-card-south {
-  --card-width-base: calc(120px * var(--card-size-human, 1));
-  --card-height-base: calc(168px * var(--card-size-human, 1));
+  --card-width-base: calc(120px * var(--card-scale));
+  --card-height-base: calc(168px * var(--card-scale));
 }
 
 .trick-card-north,
 .trick-card-east,
 .trick-card-west {
-  --card-width-base: calc(120px * var(--card-size-ai, 1));
-  --card-height-base: calc(168px * var(--card-size-ai, 1));
+  --card-width-base: calc(120px * var(--ai-card-scale));
+  --card-height-base: calc(168px * var(--ai-card-scale));
 }

--- a/src/components/TrickArea.tsx
+++ b/src/components/TrickArea.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { TrickCard } from '../core/types';
 import Card from './Card';
-import { useAppSelector } from '../store/hooks';
 
 interface TrickAreaProps {
   currentTrick: TrickCard[];
@@ -11,7 +10,6 @@ interface TrickAreaProps {
 }
 
 const TrickArea: React.FC<TrickAreaProps> = ({ currentTrick, isDropActive, trickWinner }) => {
-  const cardSize = useAppSelector(state => state.game.settings?.cardSize || 'medium');
   
   
   
@@ -134,7 +132,6 @@ const TrickArea: React.FC<TrickAreaProps> = ({ currentTrick, isDropActive, trick
             >
               <Card
                 card={trickCard.card}
-                size={cardSize as 'small' | 'medium' | 'large' | 'xlarge'}
                 className="shadow-2xl"
               />
               

--- a/src/components/TrickPile.tsx
+++ b/src/components/TrickPile.tsx
@@ -15,25 +15,10 @@ const TrickPile: React.FC<TrickPileProps> = ({ teamId, position, currentTrickNum
   const [showViewer, setShowViewer] = useState(false);
   const settings = useAppSelector(state => state.game.settings);
   const tricks = useAppSelector(teamId === 'A' ? selectTeamATricks : selectTeamBTricks);
-  const cardSize = settings?.cardSize || 'medium';
   const showPoints = settings?.showTrickPilePoints || false;
   
   if (tricks.length === 0) return null;
   
-  // Size classes based on card size setting
-  const sizeClasses = {
-    small: 'w-16 h-24',
-    medium: 'w-20 h-28',
-    large: 'w-24 h-32',
-    xlarge: 'w-32 h-44'
-  };
-  
-  const badgeSizes = {
-    small: 'w-6 h-6 text-xs',
-    medium: 'w-8 h-8 text-sm',
-    large: 'w-10 h-10 text-base',
-    xlarge: 'w-12 h-12 text-lg'
-  };
 
   return (
     <>
@@ -45,7 +30,13 @@ const TrickPile: React.FC<TrickPileProps> = ({ teamId, position, currentTrickNum
         onClick={() => setShowViewer(true)}
       >
         {/* Card stack visual */}
-        <div className={`relative ${sizeClasses[cardSize]}`}>
+        <div
+          className="relative"
+          style={{
+            width: 'calc(var(--card-width) * var(--card-scale) * 0.8)',
+            height: 'calc(var(--card-height) * var(--card-scale) * 0.8)'
+          }}
+        >
           {/* Shadow cards to create stack effect */}
           {tricks.slice(0, Math.min(3, tricks.length)).map((_, index) => (
             <div
@@ -77,9 +68,14 @@ const TrickPile: React.FC<TrickPileProps> = ({ teamId, position, currentTrickNum
           
           {/* Trick count badge */}
           <motion.div
-            className={`absolute -top-2 -right-2 ${badgeSizes[cardSize]} ${
+            className={`absolute -top-2 -right-2 ${
               teamId === 'A' ? 'bg-blue-500' : 'bg-red-500'
             } rounded-full flex items-center justify-center shadow-lg`}
+            style={{
+              width: 'calc(var(--card-width) * var(--card-scale) * 0.3)',
+              height: 'calc(var(--card-width) * var(--card-scale) * 0.3)',
+              fontSize: '0.75rem'
+            }}
             initial={{ scale: 0 }}
             animate={{ scale: 1 }}
             transition={{ delay: 0.2 }}

--- a/src/game/GameManager.ts
+++ b/src/game/GameManager.ts
@@ -47,19 +47,8 @@ export class GameManager {
     store.dispatch(updateSettings({ animationSpeed: speed }));
   }
   
-  setCardSize(size: number) {
-    // Convert numeric scale to old size categories for Redux store compatibility
-    let sizeCategory: 'small' | 'medium' | 'large' | 'xlarge';
-    if (size < 0.7) {
-      sizeCategory = 'small';
-    } else if (size < 0.9) {
-      sizeCategory = 'medium';
-    } else if (size < 1.1) {
-      sizeCategory = 'large';
-    } else {
-      sizeCategory = 'xlarge';
-    }
-    store.dispatch(updateSettings({ cardSize: sizeCategory }));
+  setCardScale(size: number) {
+    store.dispatch(updateSettings({ cardScale: size }));
   }
 
   // Player actions

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -18,7 +18,7 @@ import {
 
 // Game Settings interface
 export interface GameSettings {
-  cardSize: 'small' | 'medium' | 'large' | 'xlarge';
+  cardScale: number;
   cardStyle: 'classic' | 'modern' | 'accessible' | 'minimalist';
   soundEnabled: boolean;
   animationSpeed: 'slow' | 'normal' | 'fast';
@@ -63,7 +63,7 @@ const createInitialProfile = (): PlayerProfile => ({
 // Initial state factory
 const createInitialState = (): GameState => {
   // Load saved settings
-  const savedCardSize = localStorage.getItem('cardSize') as 'small' | 'medium' | 'large' | 'xlarge' | null;
+  const savedCardScale = parseFloat(localStorage.getItem('cardScale') || '1');
   // Create players - counterclockwise order: South -> East -> North -> West
   const players: Player[] = [
     {
@@ -143,7 +143,7 @@ const createInitialState = (): GameState => {
     lastRoundScore: null,
     roundHistory: [],
     settings: {
-      cardSize: savedCardSize || 'large',  // Default to large for low vision
+      cardScale: savedCardScale || 1,
       cardStyle: 'classic',  // Default to classic style
       soundEnabled: true,
       animationSpeed: 'normal',
@@ -552,7 +552,7 @@ const gameSlice = createSlice({
     },
 
     updateSettings: (state, action: PayloadAction<Partial<{
-      cardSize: 'small' | 'medium' | 'large' | 'xlarge';
+      cardScale: number;
       cardStyle: 'classic' | 'modern' | 'accessible' | 'minimalist';
       soundEnabled: boolean;
       animationSpeed: 'slow' | 'normal' | 'fast';
@@ -562,7 +562,7 @@ const gameSlice = createSlice({
     }>>) => {
       if (!state.settings) {
         state.settings = {
-          cardSize: 'large',  // Default to large for low vision
+          cardScale: 1,
           cardStyle: 'classic',
           soundEnabled: true,
           animationSpeed: 'normal',

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -36,6 +36,10 @@
   --card-height: clamp(84px, 14vw, 168px);
   --card-corner-radius: clamp(4px, 0.8vw, 12px);
   --card-shadow-blur: clamp(8px, 1vw, 16px);
+  /* Global scale applied to all card elements */
+  --card-scale: 1;
+  /* AI players slightly smaller than human controlled cards */
+  --ai-card-scale: calc(0.8 + 0.2 * var(--card-scale));
   
   /* Button dimensions */
   --button-height: clamp(2rem, 5vw, 3rem);


### PR DESCRIPTION
## Summary
- switch to numeric `cardScale` in settings
- store `--card-scale` css variable and derive `--ai-card-scale`
- unify PlayerHandFlex and TrickArea to use the new card scale
- remove legacy size categories
- update trick pile to compute sizes from CSS vars

## Testing
- `npm test` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842d29726288327afa052e5f43ea88b