### PR TITLE
Display scoreboard after each round

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,17 @@ function GameContent() {
     }
   }, [gamePhase, lastRoundScore]);
 
+  // Automatically show the detailed scoreboard for 4 seconds after each round
+  useEffect(() => {
+    if (lastRoundScore && gamePhase !== GamePhase.GameOver) {
+      setShowDetailedScoreboard(true);
+      const timer = setTimeout(() => {
+        setShowDetailedScoreboard(false);
+      }, 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [lastRoundScore, gamePhase]);
+
   // Show victory celebration on game over
   useEffect(() => {
     if (gamePhase === GamePhase.GameOver && winner) {

--- a/src/game/GameFlowController.ts
+++ b/src/game/GameFlowController.ts
@@ -459,7 +459,8 @@ export class GameFlowController {
     // Update AI profiles based on round results
     this.updateAIProfilesAfterRound();
     
-    await this.delay(2000); // Show scores
+    // Pause before dealing next round so players can view the scoreboard
+    await this.delay(4000);
     
     // Continue to next round or game over
     if (this.getState().game.phase === GamePhase.Dealing) {


### PR DESCRIPTION
## Summary
- automatically show `DetailedScoreboard` for 4 seconds after each round
- pause game flow for 4 seconds so players can review scores

## Testing
- `npm test` *(fails: browserType.launch: executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68430c2f29208327ada45046d5ebbe1f