### PR TITLE
Add ESC closing for modals and card zoom

### DIFF
--- a/src/accessibility/AccessibilitySettings.tsx
+++ b/src/accessibility/AccessibilitySettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAccessibility } from './AccessibilityContext';
 
@@ -9,6 +9,19 @@ interface AccessibilitySettingsProps {
 
 export const AccessibilitySettings: React.FC<AccessibilitySettingsProps> = ({ isOpen, onClose }) => {
   const { settings, updateSettingPath, resetSettings } = useAccessibility();
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
 
   return (
     <AnimatePresence>

--- a/src/accessibility/KeyboardHelp.tsx
+++ b/src/accessibility/KeyboardHelp.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 interface KeyboardHelpProps {
@@ -17,6 +17,19 @@ export const KeyboardHelp: React.FC<KeyboardHelpProps> = ({ isOpen, onClose }) =
     { key: 'Shift+Tab', description: 'Navigate backwards' },
     { key: '?', description: 'Show this help' }
   ];
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
 
   return (
     <AnimatePresence>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -160,6 +160,19 @@ const Card: React.FC<CardProps> = ({
     }
   }, [isDraggable, drag]);
 
+  // Close zoom on global Escape press
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isZoomed) {
+        dispatch(toggleCardZoom(null));
+      }
+    };
+    if (isZoomed) {
+      document.addEventListener('keydown', handleEsc);
+      return () => document.removeEventListener('keydown', handleEsc);
+    }
+  }, [isZoomed, dispatch]);
+
   // Font sizes use CSS custom properties
   const fontClasses = {
     main: 'card-main-text',

--- a/src/components/DetailedScoreboard.tsx
+++ b/src/components/DetailedScoreboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppSelector } from '../store/hooks';
 import ContractBadge from './ContractBadge';
@@ -33,6 +33,19 @@ const DetailedScoreboard: React.FC<DetailedScoreboardProps> = ({ show, onClose }
   };
   
   const cumulativeScores = getCumulativeScores();
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (show) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [show, onClose]);
   
   return (
     <AnimatePresence>

--- a/src/components/ScoreBreakdown.tsx
+++ b/src/components/ScoreBreakdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { RoundScore } from '../core/types';
 
@@ -9,13 +9,26 @@ interface ScoreBreakdownProps {
   rawPoints?: { A: number; B: number };
 }
 
-const ScoreBreakdown: React.FC<ScoreBreakdownProps> = ({ 
-  isOpen, 
-  onClose, 
+const ScoreBreakdown: React.FC<ScoreBreakdownProps> = ({
+  isOpen,
+  onClose,
   roundScore,
-  rawPoints 
+  rawPoints
 }) => {
   if (!roundScore) return null;
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
 
 
   return (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSoundSettings } from '../utils/soundManager';
 import { gameManager } from '../game/GameManager';
@@ -53,6 +53,19 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
     setRightClickZoom(enabled);
     dispatch(updateSettings({ rightClickZoom: enabled }));
   };
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
 
   return (
     <AnimatePresence>

--- a/src/components/TrickPileViewer.tsx
+++ b/src/components/TrickPileViewer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Trick, Suit } from '../core/types';
 import Card from './Card';
@@ -30,6 +30,17 @@ const TrickPileViewer: React.FC<TrickPileViewerProps> = ({ tricks, teamId, onClo
       onClose();
     }
   }, [lastTrick, onClose]);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
   
   if (!lastTrick) {
     return null;

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 
@@ -9,6 +9,19 @@ interface TutorialProps {
 
 const Tutorial: React.FC<TutorialProps> = ({ isOpen, onClose }) => {
   const [currentPage, setCurrentPage] = useState(0);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onClose]);
 
   const pages = [
     {


### PR DESCRIPTION
## Summary
- allow Escape key to exit zoomed card view
- enable Escape key to close Settings, Score Breakdown, Detailed Scoreboard, Tutorial, Keyboard Help, Accessibility Settings and Trick Pile Viewer

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430d6065fc8327bc3ca47af61e7a80