### PR TITLE
Fix player card layout issues

### DIFF
--- a/src/components/PlayerHandFlex.css
+++ b/src/components/PlayerHandFlex.css
@@ -24,7 +24,7 @@
 .ph-flex-wrapper[data-position="north"],
 .ph-flex-wrapper[data-position="east"],
 .ph-flex-wrapper[data-position="west"] {
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* Flex container for cards */
@@ -133,7 +133,9 @@
 
 .ph-flex-wrapper[data-position="north"] .ph-flex-card {
   flex: 0 0 auto;
-  width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * 0.7);
+
+  --dynamic-card-width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * var(--north-card-size));
+  width: var(--dynamic-card-width);
 
   /* Negative margin for overlap - using compact ratio */
   margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));
@@ -161,8 +163,11 @@
 .ph-flex-wrapper[data-position="east"] .ph-flex-card,
 .ph-flex-wrapper[data-position="west"] .ph-flex-card {
   flex: 0 0 auto;
-  width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * 0.5);
-  height: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * 0.5);
+
+  --dynamic-card-width: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * var(--side-card-size));
+  --dynamic-card-height: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * var(--side-card-size));
+  width: var(--dynamic-card-width);
+  height: var(--dynamic-card-height);
 
   /* Negative margin to create overlap - using compact ratio */
   margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));

--- a/src/components/PlayerZone.css
+++ b/src/components/PlayerZone.css
@@ -6,13 +6,30 @@
   flex: 1 1 auto; /* Allow growing and shrinking */
   min-width: 0;
   min-height: 0;
-  width: var(--hand-container-width);
-  height: var(--hand-container-height);
+  width: auto;
+  height: auto;
   max-width: 100%;
   max-height: 100%;
   position: relative;
-  z-index: var(--z-south-player);
+  z-index: var(--z-north-player);
   overflow: visible;
+}
+
+/* Individual z-index tokens for each position */
+.player-zone-north {
+  z-index: var(--z-north-player);
+}
+
+.player-zone-east {
+  z-index: var(--z-east-player);
+}
+
+.player-zone-west {
+  z-index: var(--z-west-player);
+}
+
+.player-zone-south {
+  z-index: var(--z-south-player);
 }
 
 /* Player name positioning */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -123,6 +123,9 @@
   --z-table-surface: 1;      /* Table decorations, center circle */
   --z-card-base: 10;         /* All player cards start here */
   --z-trick-cards: 20;       /* Cards in trick area */
+  --z-north-player: 20;      /* AI opponent */
+  --z-east-player: 20;       /* AI opponent */
+  --z-west-player: 20;       /* AI opponent */
   --z-south-player: 25;      /* Human player priority */
   --z-player-indicator: 30;
   --z-card-hover: 40;        /* Hovered cards */
@@ -213,6 +216,8 @@
   );
   /* Quantifiable sizing for south player's hand */
   --south-card-size: 0.8;      /* Multiplier for card dimensions */
+  --north-card-size: 0.75;     /* Multiplier for north player's cards */
+  --side-card-size: 0.6;       /* Multiplier for east/west players */
   --south-card-spacing: 0.5;   /* Multiplier for arc rotation step */
 
   /* Arc layout variables for PlayerHandFlex */


### PR DESCRIPTION
## Summary
- avoid clipping by keeping AI player hand overflow visible
- make player z-index configurable per position
- adjust card scaling with new tokens
- set auto sizing on player zones

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68431e9f65d88327a83d3fbda656fe6c