### PR TITLE
Display scoreboard after each round

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,23 @@ function GameContent() {
     }
   }, [gamePhase, lastRoundScore]);
 
+  // Automatically show the detailed scoreboard at the end of each round
+  useEffect(() => {
+    if (lastRoundScore && gamePhase !== GamePhase.GameOver) {
+      const showTimer = setTimeout(() => {
+        setShowDetailedScoreboard(true);
+      }, 1000);
+      const hideTimer = setTimeout(() => {
+        setShowDetailedScoreboard(false);
+      }, 5000); // 1s delay then visible for 4s
+
+      return () => {
+        clearTimeout(showTimer);
+        clearTimeout(hideTimer);
+      };
+    }
+  }, [lastRoundScore, gamePhase]);
+
   // Show victory celebration on game over
   useEffect(() => {
     if (gamePhase === GamePhase.GameOver && winner) {

--- a/src/components/DetailedScoreboard.tsx
+++ b/src/components/DetailedScoreboard.tsx
@@ -14,6 +14,18 @@ const DetailedScoreboard: React.FC<DetailedScoreboardProps> = ({ show, onClose }
   const teams = useAppSelector(state => state.game.teams);
   const targetScore = useAppSelector(state => state.game.targetScore);
   const currentRound = useAppSelector(state => state.game.round);
+
+  // Allow closing with Escape key
+  React.useEffect(() => {
+    if (!show) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [show, onClose]);
   
   // Calculate cumulative scores
   const getCumulativeScores = () => {

--- a/src/game/GameFlowController.ts
+++ b/src/game/GameFlowController.ts
@@ -459,7 +459,8 @@ export class GameFlowController {
     // Update AI profiles based on round results
     this.updateAIProfilesAfterRound();
     
-    await this.delay(2000); // Show scores
+    // Pause before dealing next round so players can view the scoreboard
+    await this.delay(5000);
     
     // Continue to next round or game over
     if (this.getState().game.phase === GamePhase.Dealing) {


### PR DESCRIPTION
## Summary
- show scoreboard one second after a round finishes
- auto-hide scoreboard after four seconds
- allow closing the scoreboard with Escape
- pause the game for five seconds after scoring so players can view scores

## Testing
- `npm test` *(fails: browserType.launch: executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68430c2f29208327ada45046d5ebbe1f