### PR TITLE
Add customizable card sizes and spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,9 +255,18 @@ function GameContent() {
 function App() {
   // Initialize card scale from localStorage on mount
   useEffect(() => {
-    const savedCardScale = localStorage.getItem('cardScale');
-    const size = savedCardScale ? parseFloat(savedCardScale) : 1.0;
-    document.documentElement.style.setProperty('--card-scale', size.toString());
+    const root = document.documentElement;
+    const savedCardScale = parseFloat(localStorage.getItem('cardScale') || '1');
+    root.style.setProperty('--card-scale', savedCardScale.toString());
+
+    const southSize = parseFloat(localStorage.getItem('southCardSize') || '0.8');
+    root.style.setProperty('--south-card-size', southSize.toString());
+    const southSpacing = parseFloat(localStorage.getItem('southCardSpacing') || '0.5');
+    root.style.setProperty('--south-card-spacing', southSpacing.toString());
+    const aiSize = parseFloat(localStorage.getItem('aiCardSize') || '0.75');
+    root.style.setProperty('--ai-card-size', aiSize.toString());
+    const aiSpacing = parseFloat(localStorage.getItem('aiCardSpacing') || '1');
+    root.style.setProperty('--ai-card-spacing', aiSpacing.toString());
   }, []);
 
   return (

--- a/src/components/PlayerHandFlex.css
+++ b/src/components/PlayerHandFlex.css
@@ -138,7 +138,7 @@
   width: var(--dynamic-card-width);
 
   /* Negative margin for overlap - using compact ratio */
-  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));
+  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact) * var(--ai-card-spacing)));
 }
 
 /* Last card shouldn't have negative margin */
@@ -148,7 +148,7 @@
 
 /* Dynamic overlap based on card count for North player */
 .ph-flex-wrapper[data-position="north"][data-card-count="8"] .ph-flex-card {
-  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight)));
+  margin-right: calc(var(--card-width) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight) * var(--ai-card-spacing)));
 }
 
 /* EAST/WEST PLAYERS - Vertical flex with rotation */
@@ -170,7 +170,7 @@
   height: var(--dynamic-card-height);
 
   /* Negative margin to create overlap - using compact ratio */
-  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact)));
+  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-compact) * var(--ai-card-spacing)));
 }
 
 /* Last card shouldn't have negative margin */
@@ -182,7 +182,7 @@
 /* Dynamic overlap based on card count for East/West players */
 .ph-flex-wrapper[data-position="east"][data-card-count="8"] .ph-flex-card,
 .ph-flex-wrapper[data-position="west"][data-card-count="8"] .ph-flex-card {
-  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight)));
+  margin-bottom: calc(var(--card-height) * var(--ph-card-scale) * var(--card-scale) * calc(-1 * var(--card-overlap-tight) * var(--ai-card-spacing)));
 }
 
 .ph-flex-wrapper[data-position="east"] .ph-flex-card {
@@ -201,12 +201,12 @@
 
 /* Responsive card overlap using clamp() - fixed at 50% */
 .ph-flex-wrapper[data-position="north"] .ph-flex-card {
-  margin-right: calc(var(--dynamic-card-width) * -0.5);
+  margin-right: calc(var(--dynamic-card-width) * -0.5 * var(--ai-card-spacing));
 }
 
 .ph-flex-wrapper[data-position="east"] .ph-flex-card,
 .ph-flex-wrapper[data-position="west"] .ph-flex-card {
-  margin-bottom: calc(var(--dynamic-card-height) * -0.5);
+  margin-bottom: calc(var(--dynamic-card-height) * -0.5 * var(--ai-card-spacing));
 }
 
 /* Responsive arc effect for south player using clamp() and --card-index */
@@ -320,7 +320,7 @@
 @media (width <= 400px) {
   /* South player - more overlap for 8 cards */
   .ph-flex-wrapper[data-position="south"] .ph-flex-card {
-    margin-right: calc(var(--dynamic-card-width) * -0.4);
+    margin-right: calc(var(--dynamic-card-width) * -0.4 * var(--ai-card-spacing));
   }
   
   /* Reduce arc effect on very small screens */
@@ -331,7 +331,7 @@
   
   /* North player - extreme overlap */
   .ph-flex-wrapper[data-position="north"] .ph-flex-card {
-    margin-right: calc(var(--dynamic-card-width) * -0.6);
+    margin-right: calc(var(--dynamic-card-width) * -0.6 * var(--ai-card-spacing));
   }
 }
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -20,6 +20,18 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
   const [cardSize, setCardSize] = useState<number>(
     parseFloat(localStorage.getItem('cardScale') || '1.0')  // Default to 1.0 (100%)
   );
+  const [southCardSize, setSouthCardSize] = useState<number>(
+    parseFloat(localStorage.getItem('southCardSize') || '0.8')
+  );
+  const [southCardSpacing, setSouthCardSpacing] = useState<number>(
+    parseFloat(localStorage.getItem('southCardSpacing') || '0.5')
+  );
+  const [aiCardSize, setAICardSize] = useState<number>(
+    parseFloat(localStorage.getItem('aiCardSize') || '0.75')
+  );
+  const [aiCardSpacing, setAICardSpacing] = useState<number>(
+    parseFloat(localStorage.getItem('aiCardSpacing') || '1')
+  );
   const [showTrickPilePoints, setShowTrickPilePoints] = useState(gameSettings?.showTrickPilePoints || false);
   const [rightClickZoom, setRightClickZoom] = useState(gameSettings?.rightClickZoom ?? true);
 
@@ -42,6 +54,34 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
 
     dispatch(updateSettings({ cardScale: size }));
     gameManager.setCardScale(size);
+  };
+
+  const handleSouthCardSizeChange = (size: number) => {
+    setSouthCardSize(size);
+    localStorage.setItem('southCardSize', size.toString());
+    document.documentElement.style.setProperty('--south-card-size', size.toString());
+    dispatch(updateSettings({ southCardSize: size }));
+  };
+
+  const handleSouthCardSpacingChange = (spacing: number) => {
+    setSouthCardSpacing(spacing);
+    localStorage.setItem('southCardSpacing', spacing.toString());
+    document.documentElement.style.setProperty('--south-card-spacing', spacing.toString());
+    dispatch(updateSettings({ southCardSpacing: spacing }));
+  };
+
+  const handleAICardSizeChange = (size: number) => {
+    setAICardSize(size);
+    localStorage.setItem('aiCardSize', size.toString());
+    document.documentElement.style.setProperty('--ai-card-size', size.toString());
+    dispatch(updateSettings({ aiCardSize: size }));
+  };
+
+  const handleAICardSpacingChange = (spacing: number) => {
+    setAICardSpacing(spacing);
+    localStorage.setItem('aiCardSpacing', spacing.toString());
+    document.documentElement.style.setProperty('--ai-card-spacing', spacing.toString());
+    dispatch(updateSettings({ aiCardSpacing: spacing }));
   };
 
   const handleShowTrickPilePointsChange = (show: boolean) => {
@@ -183,8 +223,64 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
                         </button>
                       ))}
                     </div>
+                </div>
+              </div>
+                {/* Hand Layout Settings */}
+                <div>
+                  <h3 className="text-lg font-semibold text-white mb-4">Hand Layout</h3>
+
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm text-slate-400 mb-2">South Card Size</label>
+                      <input
+                        type="range"
+                        min="0.5"
+                        max="1.2"
+                        step="0.05"
+                        value={southCardSize}
+                        onChange={(e) => handleSouthCardSizeChange(parseFloat(e.target.value))}
+                        className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider-thumb"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-400 mb-2">South Card Spacing</label>
+                      <input
+                        type="range"
+                        min="0.3"
+                        max="1"
+                        step="0.05"
+                        value={southCardSpacing}
+                        onChange={(e) => handleSouthCardSpacingChange(parseFloat(e.target.value))}
+                        className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider-thumb"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-400 mb-2">AI Card Size</label>
+                      <input
+                        type="range"
+                        min="0.5"
+                        max="1.2"
+                        step="0.05"
+                        value={aiCardSize}
+                        onChange={(e) => handleAICardSizeChange(parseFloat(e.target.value))}
+                        className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider-thumb"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm text-slate-400 mb-2">AI Card Spacing</label>
+                      <input
+                        type="range"
+                        min="0.5"
+                        max="1.5"
+                        step="0.05"
+                        value={aiCardSpacing}
+                        onChange={(e) => handleAICardSpacingChange(parseFloat(e.target.value))}
+                        className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider-thumb"
+                      />
+                    </div>
                   </div>
                 </div>
+
                 {/* Sound Settings */}
                 <div>
                   <h3 className="text-lg font-semibold text-white mb-4">Sound</h3>

--- a/src/components/TrickPile.tsx
+++ b/src/components/TrickPile.tsx
@@ -33,8 +33,8 @@ const TrickPile: React.FC<TrickPileProps> = ({ teamId, position, currentTrickNum
         <div
           className="relative"
           style={{
-            width: 'calc(var(--card-width) * var(--card-scale) * 0.8)',
-            height: 'calc(var(--card-height) * var(--card-scale) * 0.8)'
+            width: 'calc(var(--card-width) * var(--card-scale) * var(--ai-card-size))',
+            height: 'calc(var(--card-height) * var(--card-scale) * var(--ai-card-size))'
           }}
         >
           {/* Shadow cards to create stack effect */}

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -25,6 +25,10 @@ export interface GameSettings {
   advancedAI: boolean;
   showTrickPilePoints: boolean;
   rightClickZoom: boolean;
+  southCardSize: number;
+  southCardSpacing: number;
+  aiCardSize: number;
+  aiCardSpacing: number;
 }
 
 // Declaration tracking interface
@@ -64,6 +68,10 @@ const createInitialProfile = (): PlayerProfile => ({
 const createInitialState = (): GameState => {
   // Load saved settings
   const savedCardScale = parseFloat(localStorage.getItem('cardScale') || '1');
+  const savedSouthCardSize = parseFloat(localStorage.getItem('southCardSize') || '0.8');
+  const savedSouthCardSpacing = parseFloat(localStorage.getItem('southCardSpacing') || '0.5');
+  const savedAICardSize = parseFloat(localStorage.getItem('aiCardSize') || '0.75');
+  const savedAICardSpacing = parseFloat(localStorage.getItem('aiCardSpacing') || '1');
   // Create players - counterclockwise order: South -> East -> North -> West
   const players: Player[] = [
     {
@@ -149,7 +157,11 @@ const createInitialState = (): GameState => {
       animationSpeed: 'normal',
       advancedAI: false,
       showTrickPilePoints: false,
-      rightClickZoom: true
+      rightClickZoom: true,
+      southCardSize: savedSouthCardSize,
+      southCardSpacing: savedSouthCardSpacing,
+      aiCardSize: savedAICardSize,
+      aiCardSpacing: savedAICardSpacing
     },
     zoomedCard: null,
     declarationTracking: {},
@@ -559,6 +571,10 @@ const gameSlice = createSlice({
       advancedAI: boolean;
       showTrickPilePoints: boolean;
       rightClickZoom: boolean;
+      southCardSize: number;
+      southCardSpacing: number;
+      aiCardSize: number;
+      aiCardSpacing: number;
     }>>) => {
       if (!state.settings) {
         state.settings = {
@@ -568,7 +584,11 @@ const gameSlice = createSlice({
           animationSpeed: 'normal',
           advancedAI: false,
           showTrickPilePoints: false,
-          rightClickZoom: true
+          rightClickZoom: true,
+          southCardSize: 0.8,
+          southCardSpacing: 0.5,
+          aiCardSize: 0.75,
+          aiCardSpacing: 1
         };
       }
       Object.assign(state.settings, action.payload);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -38,8 +38,10 @@
   --card-shadow-blur: clamp(8px, 1vw, 16px);
   /* Global scale applied to all card elements */
   --card-scale: 1;
-  /* AI players slightly smaller than human controlled cards */
-  --ai-card-scale: calc(0.8 + 0.2 * var(--card-scale));
+  /* Base size multiplier for AI and pile cards */
+  --ai-card-size: 0.75;
+  /* Computed scale for AI cards */
+  --ai-card-scale: calc(var(--ai-card-size) * var(--card-scale));
   
   /* Button dimensions */
   --button-height: clamp(2rem, 5vw, 3rem);
@@ -215,10 +217,11 @@
     1.0
   );
   /* Quantifiable sizing for south player's hand */
-  --south-card-size: 0.8;      /* Multiplier for card dimensions */
-  --north-card-size: 0.75;     /* Multiplier for north player's cards */
-  --side-card-size: 0.6;       /* Multiplier for east/west players */
+  --south-card-size: 0.8;      /* Multiplier for south player cards */
   --south-card-spacing: 0.5;   /* Multiplier for arc rotation step */
+  --ai-card-spacing: 1;        /* Overlap scale for north/east/west */
+  --north-card-size: var(--ai-card-size);   /* AI player cards */
+  --side-card-size: var(--ai-card-size);    /* East/West cards */
 
   /* Arc layout variables for PlayerHandFlex */
   --ph-arc-rotation-base: -17.5deg; /* starting rotation for leftmost card */
@@ -260,7 +263,8 @@
   
   /* ===== TRICK PILE VIEWER ===== */
   --trick-pile-width: clamp(200px, 40vw, 400px);
-  --trick-pile-card-size: clamp(60px, 8vw, 100px);
+  /* Size of cards in trick pile viewer */
+  --trick-pile-card-size: calc(var(--card-width) * var(--ai-card-size));
   --trick-pile-padding: clamp(1rem, 2vw, 2rem);
   --trick-pile-gap: clamp(0.5rem, 1vw, 1rem);
   


### PR DESCRIPTION
## Summary
- add new CSS variables for south and AI card settings
- enable dynamic spacing for north, east, and west hands
- expose hand layout controls in settings panel
- persist layout settings via Redux and localStorage
- apply new card sizing in trick piles and app initialization

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684335ac2d8083278d59e8b066341c0d